### PR TITLE
Feature/license plates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl http://localhost:5000/version
 
 `/users` registers a new user:
 
-```
+```bash
 curl -X POST \
      -H 'Content-Type: application/json' \
      -d '{ "email": "indidu@lambda.net",

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ curl -X POST \
      http://localhost:5000/users
 ```
 
+`/license-plates` registers a license plate for the authenticated user:
+
+```bash
+curl -X POST \
+     -H 'Cookies: {{A valid session cookie}}' \
+     -H 'Content-Type: application/json' \
+     -d '{ "number": "H20 HCL"}' \
+     http://localhost:5000/license-plates
+```
+
 `/login` creates a user session, and returns the user:
 
 ```bash

--- a/alerte_blanche.py
+++ b/alerte_blanche.py
@@ -1,5 +1,7 @@
 import os
 
+from functools import wraps
+
 from peewee import CharField
 from peewee import DoesNotExist
 from peewee import ForeignKeyField
@@ -66,6 +68,15 @@ app.secret_key = b'\xb5\xf2v\xba\x8d\x1b\x86\xabO\xc9\x8e\x1a<m\x17mC1\xf4<\x18\
 FLASK_DEBUG = os.environ.get('FLASK_DEBUG', False)
 
 
+def login_required(func):
+    @wraps(func)
+    def inner(*args, **kwargs):
+        print(session.get('user_id'))
+        if not session.get('user_id'):
+            return ('unauthenticated', 401)
+        return func(*args, **kwargs)
+    return inner
+
 @app.route("/version")
 def version():
     version_dict = {
@@ -88,6 +99,7 @@ def register():
 
 
 @app.route("/license-plates", methods=['POST'])
+@login_required
 def register_license_plate():
     user_id = session['user_id']
     number = request.json['number']


### PR DESCRIPTION
Add plates endpoint + DB models.

Now, the `/license-plates` can be used to add a license plate.
The user needs to be authenticated.

Docs updated accordingly.